### PR TITLE
feature(backend): refactor extractor logic to include unigram, bigram, and trigram but excluded subgram  

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 
 desc 'Run tests once'
 Rake::TestTask.new(:spec) do |t|
-  t.pattern = 'spec/*_spec.rb'
+  t.pattern = 'spec/**/*_spec.rb'
   t.warning = false
 end
 

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1,6 +1,83 @@
 {
   "RSpec": {
     "coverage": {
+      "/home/poyasharonlin/SOA/Project/sangria/spec/domain/entities/concepts_spec.rb": {
+        "lines": [
+          null
+        ]
+      },
+      "/home/poyasharonlin/SOA/Project/sangria/spec/domain/entities/papers_spec.rb": {
+        "lines": [
+          null
+        ]
+      },
+      "/home/poyasharonlin/SOA/Project/sangria/spec/domain/entities/query_spec.rb": {
+        "lines": [
+          null
+        ]
+      },
+      "/home/poyasharonlin/SOA/Project/sangria/spec/domain/services/embedder_spec.rb": {
+        "lines": [
+          null
+        ]
+      },
+      "/home/poyasharonlin/SOA/Project/sangria/spec/domain/services/extractor_spec.rb": {
+        "lines": [
+          null,
+          1,
+          1,
+          1,
+          null,
+          1,
+          1,
+          0,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          1,
+          0,
+          null,
+          null,
+          1,
+          0,
+          null,
+          null,
+          0,
+          null,
+          0,
+          null,
+          0,
+          null,
+          0,
+          null,
+          0,
+          0,
+          0,
+          null,
+          null,
+          1,
+          0,
+          null,
+          null,
+          0,
+          null,
+          0,
+          null,
+          0,
+          null,
+          0,
+          0,
+          0,
+          0,
+          0,
+          null
+        ]
+      },
       "/home/poyasharonlin/SOA/Project/sangria/spec/infrastructure_database_spec.rb": {
         "lines": [
           null,
@@ -97,6 +174,6 @@
         ]
       }
     },
-    "timestamp": 1762416185
+    "timestamp": 1762499540
   }
 }

--- a/spec/domain/services/extractor_spec.rb
+++ b/spec/domain/services/extractor_spec.rb
@@ -1,1 +1,54 @@
-# frozen_string_literal: true
+# spec/domain/services/extractor_spec.rb
+require 'open3'
+require 'json'
+require_relative '../../helpers/spec_helper' 
+
+describe 'Concept Extractor Service' do
+  let(:summary_text) do
+    <<-TEXT
+      Natural language processing (NLP) is a subfield of linguistics,
+      computer science, and artificial intelligence concerned with the
+      interactions between computers and human language. Challenges in natural
+      language processing frequently involve speech recognition and
+      natural language understanding.
+    TEXT
+  end
+
+  let(:python_script_path) do
+    File.expand_path('../../../app/domain/clustering/services/extractor.py', __dir__)
+  end
+
+  it 'HAPPY: correctly extracts 1-3 gram concepts from text' do
+    _(File.exist?(python_script_path)).must_equal true,
+      "Python script not found at #{python_script_path}"
+
+    stdout_str, stderr_str, status = Open3.capture3("python3 #{python_script_path}", stdin_data: summary_text)
+
+    _(stderr_str).must_be_empty "Python script returned an error: #{stderr_str}"
+
+    _(status.success?).must_equal true
+
+    concepts = JSON.parse(stdout_str)
+
+    _(concepts).must_be_instance_of Array
+    _(concepts.count).must_equal 10
+    _(concepts).must_include 'natural language processing'
+  end
+
+  it 'SAD: should not include subgram in n-gram' do
+    _(File.exist?(python_script_path)).must_equal true,
+      "Python script not found at #{python_script_path}"
+
+    stdout_str, stderr_str, status = Open3.capture3("python3 #{python_script_path}", stdin_data: summary_text)
+
+    _(stderr_str).must_be_empty "Python script returned an error: #{stderr_str}"
+
+    _(status.success?).must_equal true
+
+    concepts = JSON.parse(stdout_str)
+    _(concepts).wont_include 'natural'
+    _(concepts).wont_include 'language'
+    _(concepts).wont_include 'processing'
+    _(concepts).wont_include 'natural language'
+  end
+end


### PR DESCRIPTION
**Code changes:**

- Change `extractor.py` from returning top 10 unigram to returning top 10 unigram or bigram or trigram 
If the trigram already in the top 10, its unigram and bigram form will not be in the list 
e.g: If "natural language processing" appears in top 10, then
1. Unigram such as "natural", "language", or "processing" should not be in the list
2. Bigram such as "natural language" and "language processing" should not be in the list 
 
- Add corresponding tests under `spec/domain` 
- Adjust `rake spec` pattern to include the new test 